### PR TITLE
ci: Update branch to sync from main

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repository: PaloAltoNetworks/${{ matrix.modules.repo }}
           path: ${{ matrix.modules.repo }}
-          ref: readme-updates-for-automation-hub
+          ref: main
 
       - name: Check if commit to repo today
         if: github.event.inputs.force != 'true'


### PR DESCRIPTION
## Description
Update branch to sync from main, now the source READMEs are live in `main`

## Motivation and Context
Previously the development branch was targeted

## How Has This Been Tested?
Tested with GH Actions in my forked repo, see screenshot

## Screenshots (if appropriate)
![Screenshot 2023-06-07 at 11 55 00](https://github.com/PaloAltoNetworks/automation-metadata-collector/assets/6574404/d9eb2b0f-f59e-4b87-a9b8-09aa1f88eaa8)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.