### PR TITLE
feat: Process the Example READMEs

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -80,6 +80,7 @@ jobs:
           tree .
           python ./scripts/process_modules_readmes.py "./${{ env.repo }}/modules" "./output/vmseries/modules"
           python ./scripts/process_modules_readmes.py --type refarch "./${{ env.repo }}/examples" "./output/vmseries/reference-architectures"
+          python ./scripts/process_modules_readmes.py --type example "./${{ env.repo }}/examples" "./output/vmseries/examples"
       - name: Save module readmes
         # if: steps.check_commit.outputs.changes != 'false'
         uses: actions/upload-artifact@v3

--- a/process_modules_readmes.py
+++ b/process_modules_readmes.py
@@ -272,14 +272,15 @@ def determine_module_type(readme_path: Path, readme_contents: str) -> str:
         str: Type of module
     """
     if readme_path.parts[-3] == "examples":
-        if re.search(r"reference architecture", readme_contents, re.IGNORECASE):
-            return "refarch"
-        else:
-            return "example"
-    elif readme_path.parts[-3] == "modules":
+        # If execution reaches here, frontmatter for type was not explicitly set,
+        # so we assume that this is not a Reference Architecture, and hence
+        # set the type to be an Example, based on the path of this README file
+        return "example"
+    if readme_path.parts[-3] == "modules":
+        # If execution reaches here, frontmatter for type was not explicitly set,
+        # so we assume this is a module based on the path of this README file
         return "module"
-    else:
-        raise ValueError(f"Could not determine module type from path: {readme_path}")
+    raise ValueError(f"Could not determine module type from path: {readme_path}")
 
 def delete_markdown_files(directory: Path):
     """Delete all markdown files in the directory
@@ -462,7 +463,7 @@ def main(modules_directory: str, dest_directory: str, module_type: str = None):
     """
     dest_directory_path = Path(dest_directory)
     tf_modules = get_module_readme_files(Path(modules_directory))
-    if module_type is not None:
+    if module_type is not None: # if module_type is supplied at execution time, only process modules of that type
         tf_modules = [module for module in tf_modules if module.type == module_type]
     output_files: list[OutputFile] = []
     images: list[dict[str, bytes]] = []


### PR DESCRIPTION
## Description
Process the Example READMEs, previously only Ref Archs and Modules were processed

## Motivation and Context
Evolution of pan.dev, adding a new Examples section, requires READMEs to be processed and sync'd

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate)
New examples section after local testing:
![Screenshot 2023-07-19 at 21 54 44](https://github.com/PaloAltoNetworks/automation-metadata-collector/assets/6574404/d2b68042-9481-4ba1-b13c-7d4623055221)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.