### PR TITLE
Add VPN to KNOWN_ACRYONYMS

### DIFF
--- a/process_modules_readmes.py
+++ b/process_modules_readmes.py
@@ -25,6 +25,7 @@ KNOWN_ACRYONYMS = [
     "lb",
     "http",
     "iam",
+    "vpn",
 ]
 
 T = TypeVar('T')


### PR DESCRIPTION
## Description

VPN was not displayed in capital letters and added to KNOWN_ACRYONYMS

## Screenshots (if appropriate)

![image](https://github.com/PaloAltoNetworks/automation-metadata-collector/assets/6500664/8db6441a-63ff-4a7d-8b4a-1f94222ff021)
