### PR TITLE
fix: Fix path to vmseries docs in pan.dev

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -117,18 +117,21 @@ jobs:
       - name: Add generated docs to pan.dev
         run: |
           if [ -d output/aws ]; then
-            rm -rf "$SWFW_DIR/aws/modules/*"
-            rm -rf "$SWFW_DIR/aws/reference-architectures/*"
+            rm -rf "$SWFW_DIR/aws/vmseries/modules/*"
+            rm -rf "$SWFW_DIR/aws/vmseries/reference-architectures/*"
+            rm -rf "$SWFW_DIR/aws/vmseries/examples/*"
             rsync -av output/aws/ "$SWFW_DIR/aws/"
           fi
           if [ -d output/azure ]; then
-            rm -rf "$SWFW_DIR/azure/modules/*"
-            rm -rf "$SWFW_DIR/azure/reference-architectures/*"
+            rm -rf "$SWFW_DIR/azure/vmseries/modules/*"
+            rm -rf "$SWFW_DIR/azure/vmseries/reference-architectures/*"
+            rm -rf "$SWFW_DIR/azure/vmseries/examples/*"
             rsync -av output/azure/ "$SWFW_DIR/azure/"
           fi
           if [ -d output/gcp ]; then
-            rm -rf "$SWFW_DIR/gcp/modules/*"
-            rm -rf "$SWFW_DIR/gcp/reference-architectures/*"
+            rm -rf "$SWFW_DIR/gcp/vmseries/modules/*"
+            rm -rf "$SWFW_DIR/gcp/vmseries/reference-architectures/*"
+            rm -rf "$SWFW_DIR/gcp/vmseries/examples/*"
             rsync -av output/gcp/ "$SWFW_DIR/gcp/"
           fi
       - name: Print pan.dev after


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes the path to vmseries docs in pan.dev repo.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Old pan.dev docs for vmseries were not deleted before rsync of newly generated docs.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On my local workstation.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
