### PR TITLE
fix: Remove quotes from rm command

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -117,21 +117,21 @@ jobs:
       - name: Add generated docs to pan.dev
         run: |
           if [ -d output/aws ]; then
-            rm -rf "$SWFW_DIR/aws/vmseries/modules/*"
-            rm -rf "$SWFW_DIR/aws/vmseries/reference-architectures/*"
-            rm -rf "$SWFW_DIR/aws/vmseries/examples/*"
+            rm -rf $SWFW_DIR/aws/vmseries/modules/*
+            rm -rf $SWFW_DIR/aws/vmseries/reference-architectures/*
+            rm -rf $SWFW_DIR/aws/vmseries/examples/*
             rsync -av output/aws/ "$SWFW_DIR/aws/"
           fi
           if [ -d output/azure ]; then
-            rm -rf "$SWFW_DIR/azure/vmseries/modules/*"
-            rm -rf "$SWFW_DIR/azure/vmseries/reference-architectures/*"
-            rm -rf "$SWFW_DIR/azure/vmseries/examples/*"
+            rm -rf $SWFW_DIR/azure/vmseries/modules/*
+            rm -rf $SWFW_DIR/azure/vmseries/reference-architectures/*
+            rm -rf $SWFW_DIR/azure/vmseries/examples/*
             rsync -av output/azure/ "$SWFW_DIR/azure/"
           fi
           if [ -d output/gcp ]; then
-            rm -rf "$SWFW_DIR/gcp/vmseries/modules/*"
-            rm -rf "$SWFW_DIR/gcp/vmseries/reference-architectures/*"
-            rm -rf "$SWFW_DIR/gcp/vmseries/examples/*"
+            rm -rf $SWFW_DIR/gcp/vmseries/modules/*
+            rm -rf $SWFW_DIR/gcp/vmseries/reference-architectures/*
+            rm -rf $SWFW_DIR/gcp/vmseries/examples/*
             rsync -av output/gcp/ "$SWFW_DIR/gcp/"
           fi
       - name: Print pan.dev after


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR removes the quotes from the path passed to `rm` command in the `run.yml` workflow file.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `rm` command is not executed, it shows up in the workflow but takes no effect.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On my local workstation, `rm` command with the quotes goes through and doesn't error out but takes no effect. Removing the quotes from the path actually deletes the files.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
