### PR TITLE
ci: Pin GitHub Actions

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -69,7 +69,7 @@ jobs:
           path: "scripts"
       - name: Setup Python
         # if: steps.check_commit.outputs.changes != 'false'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
           python-version: "3.10"
           cache: "pip" # caching pip dependencies
@@ -87,7 +87,7 @@ jobs:
           python ./scripts/process_modules_readmes.py --type example "./${{ env.repo }}/examples" "./output/vmseries/examples"
       - name: Save module readmes
         # if: steps.check_commit.outputs.changes != 'false'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: ${{ matrix.cloudid }}
           path: output
@@ -100,11 +100,11 @@ jobs:
       SWFW_DIR: pan.dev/products/terraform/docs/swfw
     steps:
       - name: Download module readmes
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           path: output
       - name: Checkout pan.dev repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: PaloAltoNetworks/pan.dev
           path: pan.dev
@@ -140,13 +140,13 @@ jobs:
           cd "$SWFW_DIR" && git status
       - name: Generate GitHub token
         id: generate-token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@32691ba7c9e7063bd457bd8f2a5703138591fa58 # v1
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: ${{ secrets.APP_INSTALL_ID }}
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
         id: create-pull-request
         with:
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -57,14 +57,14 @@ jobs:
               echo "repo=terraform-google-swfw-modules" >> $GITHUB_ENV
           fi
       - name: Checkout module repo for ${{ matrix.cloudid }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: PaloAltoNetworks/${{ env.repo }}
           path: ${{ env.repo }}
           ref: "${{ inputs.repo_ref }}"
       - name: Checkout local scripts
         # if: steps.check_commit.outputs.changes != 'false'
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           path: "scripts"
       - name: Setup Python


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions